### PR TITLE
Make categories and tags consistent in Contact Template.md

### DIFF
--- a/Templates/Contact Template.md
+++ b/Templates/Contact Template.md
@@ -1,6 +1,8 @@
 ---
 categories:
   - "[[People]]"
+tags:
+  - people
 phone: 
 twitter: 
 org:


### PR DESCRIPTION
I noticed that all other uses of the People category all added the people tag, so it seemed a good idea to add it in the Contact template.