### PR TITLE
Fixes date handlebars for book and movie template

### DIFF
--- a/Templates/Book Template.md
+++ b/Templates/Book Template.md
@@ -10,8 +10,7 @@ isbn13:
 year:
 rating:
 topics: []
-created:
-  "{ date }":
+created: {{date}}
 last:
 via: ""
 tags:

--- a/Templates/Movie Template.md
+++ b/Templates/Movie Template.md
@@ -8,8 +8,7 @@ cast: []
 runtime:
 rating:
 year:
-last:
-  "{ date }":
+last: {{date}}
 imdbId:
 via:
 tags:


### PR DESCRIPTION
The `"{ date }"` is a holdover that has been fixed in app a while ago. This PR just recorrects the templates. :)