### PR TITLE
Updates Daily.base for Monthly view

### DIFF
--- a/Templates/Bases/Daily.base
+++ b/Templates/Bases/Daily.base
@@ -1,9 +1,9 @@
 filters:
   or:
     - file.name.contains(this.file.name)
-    - created == this.file.name
-    - start == this.file.name
-    - end == this.file.name
+    - created.toString().contains(this.file.name)
+    - start.toString().contains(this.file.name)
+    - end.toString().contains(this.file.name)
     - file.links.contains(this.file)
 properties:
   file.name:
@@ -27,13 +27,13 @@ views:
       - categories
       - tags
     sort:
-      - column: note.tags
+      - property: tags
         direction: ASC
-      - column: note.created
+      - property: created
         direction: DESC
-      - column: file.name
+      - property: file.name
         direction: ASC
-      - column: note.categories
+      - property: categories
         direction: ASC
   - type: table
     name: Monthly
@@ -46,7 +46,7 @@ views:
       - categories
       - created
     sort:
-      - column: note.created
+      - property: created
         direction: ASC
   - type: table
     name: Yearly
@@ -59,5 +59,5 @@ views:
       - categories
       - created
     sort:
-      - column: note.created
+      - property: created
         direction: ASC


### PR DESCRIPTION
Monthly view of Daily.base does not catch files unless their titles contain dates. By using the string, it catches the files through matching the date-type properties.