### PR TITLE
Fix malformed date syntax in Book Template

### DIFF
--- a/Templates/Book Template.md
+++ b/Templates/Book Template.md
@@ -10,8 +10,7 @@ isbn13:
 year:
 rating:
 topics: []
-created:
-  "{ date }":
+created: {{date}}
 last:
 via: ""
 tags:


### PR DESCRIPTION
not sure if 

`"{ date }":`

is intentional, but the other templates use {{date}} which works for core Templates plugin