### PR TITLE
Add Comics, Songs, Show episodes and basedOn/originalAuthor properties

### DIFF
--- a/.obsidian/types.json
+++ b/.obsidian/types.json
@@ -50,6 +50,8 @@
     "monthly-uses": "number",
     "runtime": "number",
     "pages": "number",
-    "acquired": "date"
+    "acquired": "date",
+    "basedOn": "multitext",
+    "originalAuthor": "multitext"
   }
 }

--- a/.obsidian/types.json
+++ b/.obsidian/types.json
@@ -51,7 +51,7 @@
     "runtime": "number",
     "pages": "number",
     "acquired": "date",
-    "basedOn": "multitext",
-    "originalAuthor": "multitext"
+    "based-on": "multitext",
+    "original-author": "multitext"
   }
 }

--- a/Categories/Comics.md
+++ b/Categories/Comics.md
@@ -1,0 +1,6 @@
+---
+tags:
+  - categories
+---
+
+![[Comics.base]]

--- a/Categories/Show episodes.md
+++ b/Categories/Show episodes.md
@@ -1,0 +1,6 @@
+---
+tags:
+  - categories
+---
+
+![[Show episodes.base]]

--- a/Categories/Songs.md
+++ b/Categories/Songs.md
@@ -1,0 +1,6 @@
+---
+tags:
+  - categories
+---
+
+![[Songs.base]]

--- a/Templates/Bases/Comics.base
+++ b/Templates/Bases/Comics.base
@@ -11,6 +11,12 @@ properties:
     displayName: Year
   note.genre:
     displayName: Genre
+  note.rating:
+    displayName: Rating
+  note.topics:
+    displayName: Topics
+  note.last:
+    displayName: Last Read
 views:
   - type: table
     name: Comics

--- a/Templates/Bases/Comics.base
+++ b/Templates/Bases/Comics.base
@@ -1,0 +1,56 @@
+filters:
+  and:
+    - note.categories.contains(link("Comics"))
+    - '!file.name.contains("Template")'
+properties:
+  note.author:
+    displayName: Author
+  file.name:
+    displayName: Name
+  note.year:
+    displayName: Year
+  note.genre:
+    displayName: Genre
+views:
+  - type: table
+    name: Comics
+    order:
+      - file.name
+      - author
+      - year
+      - rating
+      - topics
+      - last
+    sort:
+      - property: file.name
+        direction: ASC
+  - type: table
+    name: Top rated
+    order:
+      - file.name
+      - rating
+      - last
+    sort:
+      - property: last
+        direction: DESC
+  - type: table
+    name: Author
+    filters:
+      and:
+        - list(author).contains(this)
+    order:
+      - file.name
+      - year
+      - genre
+    sort:
+      - property: genre
+        direction: ASC
+  - type: table
+    name: Genre
+    filters:
+      and:
+        - list(genre).contains(this)
+    order:
+      - file.name
+      - year
+      - genre

--- a/Templates/Bases/Show episodes.base
+++ b/Templates/Bases/Show episodes.base
@@ -1,0 +1,49 @@
+filters:
+  and:
+    - note.categories.contains(link("Show episodes"))
+    - '!file.name.contains("Template")'
+properties:
+  file.name:
+    displayName: Episode
+  note.show:
+    displayName: Show
+  note.season:
+    displayName: Season
+  note.episode:
+    displayName: Episode #
+  note.rating:
+    displayName: Rating
+  note.published:
+    displayName: Published
+views:
+  - type: table
+    name: All episodes
+    order:
+      - file.name
+      - show
+      - season
+      - episode
+      - rating
+      - published
+    sort:
+      - property: published
+        direction: DESC
+      - property: file.name
+        direction: ASC
+  - type: table
+    name: Show
+    filters:
+      and:
+        - list(show).contains(this)
+    order:
+      - file.name
+      - show
+      - season
+      - episode
+      - rating
+      - published
+    sort:
+      - property: season
+        direction: ASC
+      - property: episode
+        direction: ASC

--- a/Templates/Bases/Songs.base
+++ b/Templates/Bases/Songs.base
@@ -1,0 +1,60 @@
+filters:
+  and:
+    - note.categories.contains(link("Songs"))
+    - '!file.name.contains("Template")'
+properties:
+  file.name:
+    displayName: Song
+  note.artist:
+    displayName: Artist
+  note.album:
+    displayName: Album
+  note.year:
+    displayName: Year
+  note.genre:
+    displayName: Genre
+  note.rating:
+    displayName: Rating
+views:
+  - type: table
+    name: Songs
+    order:
+      - file.name
+      - artist
+      - album
+      - rating
+      - year
+      - genre
+    sort:
+      - property: file.name
+        direction: ASC
+  - type: table
+    name: Artist
+    filters:
+      and:
+        - list(artist).contains(this)
+    order:
+      - file.name
+      - album
+      - rating
+      - year
+      - genre
+  - type: table
+    name: Album
+    filters:
+      and:
+        - list(album).contains(this)
+    order:
+      - file.name
+      - artist
+      - rating
+  - type: table
+    name: Genre
+    filters:
+      and:
+        - list(genre).contains(this)
+    order:
+      - file.name
+      - artist
+      - rating
+      - year

--- a/Templates/Book Template.md
+++ b/Templates/Book Template.md
@@ -13,8 +13,8 @@ topics: []
 created: {{date}}
 last:
 via: ""
-basedOn: []
-originalAuthor: []
+based-on: []
+original-author: []
 tags:
   - to-read
 ---

--- a/Templates/Comic Template.md
+++ b/Templates/Comic Template.md
@@ -10,8 +10,8 @@ topics: []
 created: {{date}}
 last:
 via: ""
-basedOn: []
-originalAuthor: []
+based-on: []
+original-author: []
 tags:
   - to-read
 ---

--- a/Templates/Comic Template.md
+++ b/Templates/Comic Template.md
@@ -10,6 +10,8 @@ topics: []
 created: {{date}}
 last:
 via: ""
+basedOn: []
+originalAuthor: []
 tags:
   - to-read
 ---

--- a/Templates/Comic Template.md
+++ b/Templates/Comic Template.md
@@ -1,20 +1,15 @@
 ---
 categories:
-  - "[[Books]]"
+  - "[[Comics]]"
 author: []
 cover:
 genre: []
-pages:
-isbn:
-isbn13:
 year:
 rating:
 topics: []
 created: {{date}}
 last:
 via: ""
-basedOn: []
-originalAuthor: []
 tags:
   - to-read
 ---

--- a/Templates/Movie Template.md
+++ b/Templates/Movie Template.md
@@ -11,5 +11,7 @@ year:
 last: {{date}}
 imdbId:
 via:
+basedOn: []
+originalAuthor: []
 ---
 

--- a/Templates/Movie Template.md
+++ b/Templates/Movie Template.md
@@ -11,7 +11,7 @@ year:
 last: {{date}}
 imdbId:
 via:
-basedOn: []
-originalAuthor: []
+based-on: []
+original-author: []
 ---
 

--- a/Templates/Show Template.md
+++ b/Templates/Show Template.md
@@ -7,4 +7,6 @@ cast: []
 rating:
 created: {{date}}
 last: {{date}}
+basedOn: []
+originalAuthor: []
 ---

--- a/Templates/Show Template.md
+++ b/Templates/Show Template.md
@@ -7,6 +7,6 @@ cast: []
 rating:
 created: {{date}}
 last: {{date}}
-basedOn: []
-originalAuthor: []
+based-on: []
+original-author: []
 ---

--- a/Templates/Song Template.md
+++ b/Templates/Song Template.md
@@ -1,0 +1,10 @@
+---
+categories:
+  - "[[Songs]]"
+artist: ""
+album: ""
+genre: []
+year:
+rating:
+created: {{date}}
+---

--- a/Templates/Video Game Template.md
+++ b/Templates/Video Game Template.md
@@ -8,4 +8,6 @@ system:
 rating:
 created: {{date}}
 last: {{date}}
+basedOn: []
+originalAuthor: []
 ---

--- a/Templates/Video Game Template.md
+++ b/Templates/Video Game Template.md
@@ -8,6 +8,6 @@ system:
 rating:
 created: {{date}}
 last: {{date}}
-basedOn: []
-originalAuthor: []
+based-on: []
+original-author: []
 ---


### PR DESCRIPTION
## Summary

- Add three new content type triplets (Category + Template + Base):
  - **Comics** — modeled after Books, with Author/Genre/Top rated views
  - **Songs** — modeled after Albums, with Artist/Album/Genre views
  - **Show episodes** — Category and Base for the already existing Show Episode Template
- Add `based-on` and `original-author` properties to Book, Movie, Show, Video Game, and Comic templates to track adaptations and source material
- Register `based-on` (multitext) and `original-author` (multitext) in `types.json`

## Details

### New categories

The vault already has Albums but not Songs, Shows but not Show episodes, and Books but not Comics. These are natural extensions of the existing content types:

- **Songs** complement Albums the same way Podcast episodes complement Podcasts
- **Show episodes** already had a Template (`Show Episode Template.md`) but was missing its Category and Base
- **Comics** follow the same pattern as Books (author, genre, year, rating, topics)

### based-on / original-author

Many books, movies, shows, and games are adaptations. These two properties allow tracking the source material and its original author, e.g.:

```yaml
based-on:
  - "[[Dune (novel)]]"
original-author:
  - "[[Frank Herbert]]"
```

Naming follows the kebab-case convention established by `monthly-uses` in `types.json`. (Note: `imdbId` uses camelCase, but that appears to be specific to proper noun abbreviations rather than general multi-word properties.)

### Notes

While working on this I noticed two minor inconsistencies in the existing vault (not changed in this PR):

1. **Filter syntax varies** across Bases: `Books.base` uses `categories.contains(link("Books"))` while most others use `note.categories.contains(...)`. Both work, but the convention is inconsistent.
2. **`types.json` is missing definitions** for several properties already used in templates: `show`, `episode`, `cast`, `artist`, `album`, `cover`, `via`, among others.

## Test plan

- [ ] Open the vault in Obsidian and verify the three new Category pages render their embedded Bases
- [ ] Create a test note using each new template (Comic, Song) and confirm it appears in the corresponding Base views
- [ ] Verify Show Episode Template notes appear in the new Show episodes Base
- [ ] Confirm `based-on` and `original-author` fields appear when using Book/Movie/Show/Video Game/Comic templates